### PR TITLE
use include_bytes! for target and definitions

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -40,6 +40,7 @@ mod tests {
     use super::*;
     use std::io::{Seek, SeekFrom, Write};
     use tempfile::NamedTempFile;
+    use tempdir::TempDir;
 
     fn dummy_file() -> NamedTempFile {
         let mut temp = NamedTempFile::new().unwrap();
@@ -62,8 +63,7 @@ mod tests {
 
     #[test]
     fn file_only_works_on_files() {
-        let path = "blah";
-
-        assert!(include_file(path).is_err());
+        let t = TempDir::new("blah").unwrap();
+        assert!(include_file(t.path()).is_err());
     }
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,5 +1,4 @@
 use std::path::{Path, PathBuf};
-use std::fs;
 use errors::*;
 use helpers::Locatable;
 
@@ -28,11 +27,6 @@ impl File {
     pub fn name(&self) -> &Path {
         &self.path
     }
-
-    /// The file's contents.
-    pub fn contents(&self) -> Result<fs::File> {
-        fs::File::open(&self.path).map_err(|e| e.into())
-    }
 }
 
 impl Locatable for File {
@@ -44,38 +38,33 @@ impl Locatable for File {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{Seek, SeekFrom, Write, Read};
+    use std::io::{Seek, SeekFrom, Write};
     use tempfile::NamedTempFile;
-    use tempdir::TempDir;
+    //use tempdir::TempDir;
 
-    fn dummy_file() -> (PathBuf, NamedTempFile) {
+    fn dummy_file() -> NamedTempFile {
         let mut temp = NamedTempFile::new().unwrap();
 
         write!(temp, "Hello World!").unwrap();
         temp.seek(SeekFrom::Start(0)).unwrap();
 
-        (PathBuf::from(temp.path()), temp)
+        temp
     }
 
     #[test]
     fn new_file() {
-        let (path, mut f) = dummy_file();
+        let f = dummy_file();
 
-        let file = include_file(&path).unwrap();
+        let file = include_file(&f.path()).unwrap();
 
-        let mut file_contents = Vec::new();
-        f.read_to_end(&mut file_contents).unwrap();
-
-        let mut got = Vec::new();
-        file.contents().unwrap().read_to_end(&mut got).unwrap();
-        assert_eq!(got, file_contents);
-        assert_eq!(file.name(), path);
+        assert_eq!(file.name(), f.path());
+        f.close().unwrap();
     }
 
     #[test]
     fn file_only_works_on_files() {
-        let t = TempDir::new("blah").unwrap();
+        let path = "blah";
 
-        assert!(include_file(t.path()).is_err());
+        assert!(include_file(path).is_err());
     }
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -40,7 +40,6 @@ mod tests {
     use super::*;
     use std::io::{Seek, SeekFrom, Write};
     use tempfile::NamedTempFile;
-    //use tempdir::TempDir;
 
     fn dummy_file() -> NamedTempFile {
         let mut temp = NamedTempFile::new().unwrap();

--- a/src/serialized_globs_definitions.rs
+++ b/src/serialized_globs_definitions.rs
@@ -1,0 +1,59 @@
+/// An iterator over all `DirEntries` which match the specified
+/// pattern.
+///
+/// # Note
+///
+/// You probably don't want to use this directly. Instead, you'll
+/// want the [`Dir::glob()`] method.
+///
+/// [`Dir::glob()`]: struct.Dir.html#method.glob
+pub struct Globs<'a> {
+    walker: DirWalker<'a>,
+    pattern: ::glob::Pattern,
+}
+
+impl<'a> Iterator for Globs<'a> {
+    type Item = DirEntry<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(entry) = self.walker.next() {
+            if self.pattern.matches_path(entry.path()) {
+                return Some(entry);
+            }
+        }
+
+        None
+    }
+}
+
+impl Dir {
+    /// Find all `DirEntries` which match a glob pattern.
+    ///
+    /// # Note
+    ///
+    /// This may fail if you pass in an invalid glob pattern,
+    /// consult the [glob docs] for more info on what a valid
+    /// pattern is.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use handlebars::Handlebars;
+    /// let mut handlebars = Handlebars::new();
+    ///
+    /// for entry in ASSETS.glob("*.hbs")? {
+    ///     if let DirEntry::File(f) = entry {
+    ///         let template_string = String::from_utf8(f.contents.to_vec())?;
+    ///         handlebars.register_template_string(f.name(),template_string)?;
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// [glob docs]: https://doc.rust-lang.org/glob/glob/struct.Pattern.html
+    pub fn glob<'a>(&'a self, pattern: &str) -> Result<Globs<'a>, Box<::std::error::Error>> {
+        let pattern = ::glob::Pattern::new(pattern)?;
+        Ok(Globs {
+            walker: self.walk(),
+            pattern: pattern,
+        })
+    }
+}

--- a/src/serialized_std_definitions.rs
+++ b/src/serialized_std_definitions.rs
@@ -1,0 +1,175 @@
+
+/// A single static asset.
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub struct File {
+    pub path: &'static str,
+    pub contents: &'static [u8],
+}
+
+impl File {
+    /// Get the file's path.
+    #[inline]
+    pub fn path(&self) -> &::std::path::Path {
+        self.path.as_ref()
+    }
+
+    /// The file's name (everything after the last slash).
+    pub fn name(&self) -> &str {
+        self.path().file_name().unwrap().to_str().unwrap()
+    }
+
+    /// Get a Reader over the file's contents.
+    pub fn as_reader(&self) -> ::std::io::Cursor<&[u8]> {
+        ::std::io::Cursor::new(&self.contents)
+    }
+
+    /// The total size of this file in bytes.
+    pub fn size(&self) -> usize {
+        self.contents.len()
+    }
+}
+
+/// A directory embedded as a static asset.
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub struct Dir {
+    pub path: &'static str,
+    pub files: &'static [File],
+    pub subdirs: &'static [Dir],
+}
+
+impl Dir {
+    /// Find a file which *exactly* matches the provided name.
+    pub fn find(&'static self, name: &str) -> Option<&'static File> {
+        for file in self.files {
+            if file.name() == name {
+                return Some(file);
+            }
+        }
+
+        for dir in self.subdirs {
+            if let Some(f) = dir.find(name) {
+                return Some(f);
+            }
+        }
+
+        None
+    }
+
+    /// Recursively walk the various sub-directories and files inside
+    /// the bundled asset.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// for entry in ASSET.walk() {
+    ///   match entry {
+    ///     DirEntry::File(f) => println!("{} ({} bytes)",
+    ///                                   f.path().display(),
+    ///                                   f.contents.len()),
+    ///     DirEntry::Dir(d) => println!("{} (files: {}, subdirs: {})",
+    ///                                  d.path().display(),
+    ///                                  d.files.len(),
+    ///                                  d.subdirs.len()),
+    ///   }
+    /// }
+    /// ```
+    pub fn walk<'a>(&'a self) -> DirWalker<'a> {
+        DirWalker::new(self)
+    }
+
+    /// Get the directory's name.
+    pub fn name(&self) -> &str {
+        self.path()
+            .file_name()
+            .map(|s| s.to_str().unwrap())
+            .unwrap_or("")
+    }
+
+    /// The directory's full path relative to the root.
+    pub fn path(&self) -> &::std::path::Path {
+        self.path.as_ref()
+    }
+
+    /// Get the total size of this directory and its contents in bytes.
+    pub fn size(&self) -> usize {
+        let file_size = self.files.iter().map(|f| f.size()).sum();
+
+        self.subdirs.iter().fold(file_size, |acc, d| acc + d.size())
+    }
+}
+
+/// A directory walker.
+///
+/// `DirWalker` is an iterator which will recursively traverse
+/// the embedded directory, allowing you to inspect each item.
+/// It is largely modelled on the API used by the `walkdir`
+/// crate.
+///
+/// You probably won't create one of these directly, instead
+/// prefer to use the `Dir::walk()` method.
+#[derive(Debug, PartialEq, Clone)]
+pub struct DirWalker<'a> {
+    root: &'a Dir,
+    entries_to_visit: ::std::collections::VecDeque<DirEntry<'a>>,
+}
+
+impl<'a> DirWalker<'a> {
+    fn new(root: &'a Dir) -> DirWalker<'a> {
+        let mut walker = DirWalker {
+            root: root,
+            entries_to_visit: ::std::collections::VecDeque::new(),
+        };
+        walker.extend_contents(root);
+        walker
+    }
+
+    fn extend_contents(&mut self, from: &Dir) {
+        for file in from.files {
+            self.entries_to_visit.push_back(DirEntry::File(file));
+        }
+
+        for dir in from.subdirs {
+            self.entries_to_visit.push_back(DirEntry::Dir(dir));
+        }
+    }
+}
+
+impl<'a> Iterator for DirWalker<'a> {
+    type Item = DirEntry<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let entry = self.entries_to_visit.pop_front();
+
+        if let Some(DirEntry::Dir(d)) = entry {
+            self.extend_contents(d);
+            Some(DirEntry::Dir(d))
+        } else {
+            entry
+        }
+    }
+}
+
+/// A directory entry.
+#[derive(Debug, PartialEq, Clone)]
+pub enum DirEntry<'a> {
+    Dir(&'a Dir),
+    File(&'a File),
+}
+
+impl<'a> DirEntry<'a> {
+    /// Get the entry's name.
+    pub fn name(&self) -> &str {
+        match *self {
+            DirEntry::Dir(d) => d.name(),
+            DirEntry::File(f) => f.name(),
+        }
+    }
+
+    /// Get the entry's path relative to the root directory.
+    pub fn path(&self) -> &::std::path::Path {
+        match *self {
+            DirEntry::Dir(d) => d.path(),
+            DirEntry::File(f) => f.path(),
+        }
+    }
+}


### PR DESCRIPTION
fixes #22 
* 1.5kb takes ~4 seconds (11s for release)
* 80mb takes ~9 seconds (18s for release)

issues:
* removing a file will not trigger a `build.rs` run and fails to compile `include_bytes!` fails to find the file.
* adding files will not trigger a `build.rs` run and fails to include the new file.