### PR TITLE
Problem: can't compile on Windows

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -30,7 +30,7 @@ impl<W> Serializer<W>
         write!(self.writer,
                r#"File {{ 
                 path: r"{0}", 
-                contents: include_bytes!("{0}"), 
+                contents: include_bytes!(r"{0}"),
                 }}"#,
                f.name().display())?;
 


### PR DESCRIPTION
include_dir!("..\..") doesn't have backslashes
escaped

Solution: use raw strings to avoid the issue