### PR TITLE
use include_bytes! for less memory overhead

### DIFF
--- a/include_dir_impl/src/dir.rs
+++ b/include_dir_impl/src/dir.rs
@@ -6,57 +6,49 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Dir {
-    pub path: PathBuf,
+    pub root_rel_path: PathBuf,
+    pub abs_path: PathBuf,
     pub files: Vec<File>,
     pub dirs: Vec<Dir>,
 }
 
 impl Dir {
-    pub fn from_disk<P: Into<PathBuf>>(path: P) -> Result<Dir, Error> {
-        let path = path.into();
+    pub fn from_disk<Q: AsRef<Path>, P: Into<PathBuf>>(root: Q, path: P) -> Result<Dir, Error> {
+        let abs_path = path.into();
+        let root = root.as_ref();
 
-        if !path.exists() {
+        let root_rel_path = abs_path.strip_prefix(&root).unwrap().to_path_buf();
+
+        if !abs_path.exists() {
             return Err(failure::err_msg("The directory doesn't exist"));
         }
 
         let mut files = Vec::new();
         let mut dirs = Vec::new();
 
-        for entry in path.read_dir().context("Couldn't read the directory")? {
+        for entry in abs_path.read_dir().context("Couldn't read the directory")? {
             let entry = entry?.path();
 
             if entry.is_file() {
-                files.push(File::from_disk(entry)?);
+                files.push(File::from_disk(&root, entry)?);
             } else if entry.is_dir() {
-                dirs.push(Dir::from_disk(entry)?);
+                dirs.push(Dir::from_disk(&root, entry)?);
             }
         }
 
-        Ok(Dir { path, files, dirs })
-    }
-
-    pub fn normalize(&mut self, root: &Path) {
-        self.path = self.path.strip_prefix(root).unwrap().to_path_buf();
-
-        for file in &mut self.files {
-            file.normalize(root);
-        }
-
-        for dir in &mut self.dirs {
-            dir.normalize(root);
-        }
+        Ok(Dir { root_rel_path, abs_path, files, dirs })
     }
 }
 
 impl ToTokens for Dir {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let path = self.path.display().to_string();
+        let root_rel_path = self.root_rel_path.display().to_string();
         let files = &self.files;
         let dirs = &self.dirs;
 
         let tok = quote!{
             Dir {
-                path: #path,
+                path: #root_rel_path,
                 files: &[#(
                     #files
                  ),*],

--- a/include_dir_impl/src/lib.rs
+++ b/include_dir_impl/src/lib.rs
@@ -34,8 +34,7 @@ proc_macro_expr_impl! {
 
         let path = path.canonicalize().expect("Can't normalize the path");
 
-        let mut dir = Dir::from_disk(&path).expect("Couldn't load the directory");
-        dir.normalize(&path);
+        let dir = Dir::from_disk(&path, &path).expect("Couldn't load the directory");
 
         let tokens = quote!({
                 __include_dir_use_everything!();


### PR DESCRIPTION
This uses `include_bytes!` in the expansion to have rustc generate the bytestring, rather than by `quote!`-ing bytes.  With this change, the total memory used by rustc for a crate that includes a 15 MB file drops from over 8 GB (!!) to only about 700 MB.

This is similar to #23, but that predated the `proc_macro`.

I apologize that there is a minor refactoring of the path normalization logic mixed into the same commit.  Basically I got rid of the `normalize()` methods because we need the absolute paths now, and it seemed confusing to have the source adjust these paths only to reconstruct them at the end.  It might be easier to just read the new source rather than look at the diff since it is so short anyways.

Fixes #33.

This should also resolve *some* aspects of #31 (namely for modified files), but not all. (the crate still has no way to track new files)