### PR TITLE
Update to latest proc-macro-hack and syn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-  - 1.26.0
+  - 1.31.0
   - nightly
 
 cache: cargo

--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
 name = "include_dir"
-version = "0.2.1"
+version = "0.2.2"
 description = "Embed the contents of a directory in your binary"
 license = "MIT"
 readme = "../README.md"

--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -20,10 +20,9 @@ repository = "Michael-F-Bryan/include_dir"
 
 [dependencies]
 glob = "0.2.11"
-proc-macro-hack = "0.4"
+proc-macro-hack = "0.5"
 
 [dependencies.include_dir_impl]
-#version = "0.2.1"
 path = "../include_dir_impl"
 
 [features]

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -56,20 +56,8 @@ pub use dir::Dir;
 pub use file::File;
 
 #[doc(hidden)]
-pub use include_dir_impl::*;
-
-#[macro_export]
-#[doc(hidden)]
-/// Hack used by `include_dir_impl` which can't access `$crate`.
-macro_rules! __include_dir_use_everything {
-    () => {
-        pub use $crate::*;
-    };
-}
-
-proc_macro_expr_decl! {
-    include_dir! => include_dir_impl
-}
+#[proc_macro_hack]
+pub use include_dir_impl::include_dir;
 
 /// Example the output generated when running `include_dir!()` on itself.
 #[cfg(feature = "example-output")]

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -1,5 +1,5 @@
-//! An extension to the `include_str!()` macro for embedding an entire directory
-//! tree into your binary.
+//! An extension to the `include_str!()` and `include_bytes!()` macro for embedding an entire
+//! directory tree into your binary.
 //!
 //! # Examples
 //!

--- a/include_dir_impl/Cargo.toml
+++ b/include_dir_impl/Cargo.toml
@@ -17,8 +17,8 @@ branch = "master"
 repository = "Michael-F-Bryan/include_dir"
 
 [dependencies]
-proc-macro-hack = "0.4"
-syn = "0.14.1"
+proc-macro-hack = "0.5"
+syn = "0.15"
 quote = "0.6.3"
 failure = "0.1.1"
 proc-macro2 = "0.4.4"

--- a/include_dir_impl/Cargo.toml
+++ b/include_dir_impl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
 name = "include_dir_impl"
-version = "0.2.1"
+version = "0.3.0"
 description = "Implementation crate for include_dir"
 license = "MIT"
 readme = "../README.md"

--- a/include_dir_impl/src/dir.rs
+++ b/include_dir_impl/src/dir.rs
@@ -5,11 +5,11 @@ use quote::{ToTokens, quote};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Dir {
-    pub root_rel_path: PathBuf,
-    pub abs_path: PathBuf,
-    pub files: Vec<File>,
-    pub dirs: Vec<Dir>,
+pub(crate) struct Dir {
+    root_rel_path: PathBuf,
+    abs_path: PathBuf,
+    files: Vec<File>,
+    dirs: Vec<Dir>,
 }
 
 impl Dir {

--- a/include_dir_impl/src/dir.rs
+++ b/include_dir_impl/src/dir.rs
@@ -1,7 +1,7 @@
 use failure::{self, Error, ResultExt};
 use file::File;
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{ToTokens, quote};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -47,7 +47,7 @@ impl ToTokens for Dir {
         let dirs = &self.dirs;
 
         let tok = quote!{
-            Dir {
+            $crate::Dir {
                 path: #root_rel_path,
                 files: &[#(
                     #files

--- a/include_dir_impl/src/file.rs
+++ b/include_dir_impl/src/file.rs
@@ -1,6 +1,6 @@
 use failure::{Error};
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{ToTokens, quote};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -26,7 +26,7 @@ impl ToTokens for File {
         let abs_path = self.abs_path.display().to_string();
 
         let tok = quote!{
-            File {
+            $crate::File {
                 path: #root_rel_path,
                 contents: include_bytes!(#abs_path),
             }

--- a/include_dir_impl/src/file.rs
+++ b/include_dir_impl/src/file.rs
@@ -4,9 +4,9 @@ use quote::{ToTokens, quote};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct File {
-    pub root_rel_path: PathBuf,
-    pub abs_path: PathBuf,
+pub(crate) struct File {
+    root_rel_path: PathBuf,
+    abs_path: PathBuf,
 }
 
 impl File {


### PR DESCRIPTION
Hello!

This updates the include_dir to use the latest version of proc-macro-hack and syn, which allows us to get rid of the `__include_dir_use_everything` hack. Along the way I also:

* Made some things private in `include_dir_impl`
* Replaced the example feature with a cargo /examples example.
* Tweaked a doc saying this also is an extension to `include_bytes`.
* Bumped `include_dir` to 0.2.2, and `include_dir_impl` to 0.3.0 because I changed a function name.