### PR TITLE
Switch to 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-  - 1.26.0
+  - 1.31.0
   - nightly
 
 cache: cargo

--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
 name = "include_dir"
-version = "0.2.1"
+version = "0.2.2"
 description = "Embed the contents of a directory in your binary"
 license = "MIT"
 readme = "../README.md"

--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -20,10 +20,9 @@ repository = "Michael-F-Bryan/include_dir"
 
 [dependencies]
 glob = "0.2.11"
-proc-macro-hack = "0.4"
+proc-macro-hack = "0.5"
 
 [dependencies.include_dir_impl]
-#version = "0.2.1"
 path = "../include_dir_impl"
 
 [features]

--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
 name = "include_dir"
-version = "0.2.2"
+version = "0.3.0"
 description = "Embed the contents of a directory in your binary"
 license = "MIT"
 readme = "../README.md"
 keywords = ["assets", "include", "embed", "dir"]
 repository = "https://github.com/Michael-F-Bryan/include_dir"
 categories = ["development-tools", "web-programming", "game-engines"]
+edition = "2018"
 
 [badges.appveyor]
 branch = "master"

--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -27,7 +27,6 @@ path = "../include_dir_impl"
 
 [features]
 default = []
-example-output = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/include_dir/examples/example.rs
+++ b/include_dir/examples/example.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate include_dir;
-
-use include_dir::Dir;
+use include_dir::{Dir, include_dir};
 
 /// Example the output generated when running `include_dir!()` on itself.
 pub static GENERATED_EXAMPLE: Dir = include_dir!("src");

--- a/include_dir/examples/example.rs
+++ b/include_dir/examples/example.rs
@@ -1,0 +1,13 @@
+#[macro_use]
+extern crate include_dir;
+
+use include_dir::Dir;
+
+/// Example the output generated when running `include_dir!()` on itself.
+pub static GENERATED_EXAMPLE: Dir = include_dir!("src");
+
+fn main() {
+    for file in GENERATED_EXAMPLE.files() {
+        println!("{}: {}", file.path().display(), file.contents.len());
+    }
+}

--- a/include_dir/src/dir.rs
+++ b/include_dir/src/dir.rs
@@ -1,7 +1,8 @@
-use file::File;
 use glob::{Pattern, PatternError};
-use globs::{DirEntry, Globs};
 use std::path::Path;
+
+use crate::file::File;
+use crate::globs::{DirEntry, Globs};
 
 /// A directory entry.
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/include_dir/src/globs.rs
+++ b/include_dir/src/globs.rs
@@ -1,7 +1,8 @@
-use dir::Dir;
-use file::File;
 use glob::Pattern;
 use std::path::Path;
+
+use crate::dir::Dir;
+use crate::file::File;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Globs<'a> {

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -31,13 +31,6 @@
 //! }
 //! # }
 //! ```
-//!
-//! # Features
-//!
-//! This library exposes a couple feature flags for enabling and disabling extra
-//! functionality. These are:
-//!
-//! - **example:** compile in an example of the embedded directory tree
 
 #![deny(missing_docs, missing_copy_implementations, missing_debug_implementations)]
 
@@ -58,7 +51,3 @@ pub use file::File;
 #[doc(hidden)]
 #[proc_macro_hack]
 pub use include_dir_impl::include_dir;
-
-/// Example the output generated when running `include_dir!()` on itself.
-#[cfg(feature = "example-output")]
-pub static GENERATED_EXAMPLE: Dir = include_dir!(".");

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -56,20 +56,8 @@ pub use dir::Dir;
 pub use file::File;
 
 #[doc(hidden)]
-pub use include_dir_impl::*;
-
-#[macro_export]
-#[doc(hidden)]
-/// Hack used by `include_dir_impl` which can't access `$crate`.
-macro_rules! __include_dir_use_everything {
-    () => {
-        pub use $crate::*;
-    };
-}
-
-proc_macro_expr_decl! {
-    include_dir! => include_dir_impl
-}
+#[proc_macro_hack]
+pub use include_dir_impl::include_dir;
 
 /// Example the output generated when running `include_dir!()` on itself.
 #[cfg(feature = "example-output")]

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -1,5 +1,5 @@
-//! An extension to the `include_str!()` macro for embedding an entire directory
-//! tree into your binary.
+//! An extension to the `include_str!()` and `include_bytes!()` macro for embedding an entire
+//! directory tree into your binary.
 //!
 //! # Examples
 //!

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -34,19 +34,14 @@
 
 #![deny(missing_docs, missing_copy_implementations, missing_debug_implementations)]
 
-#[allow(unused_imports)]
-#[macro_use]
-extern crate include_dir_impl;
-#[macro_use]
-extern crate proc_macro_hack;
-extern crate glob;
+use proc_macro_hack::proc_macro_hack;
 
 mod dir;
 mod file;
 mod globs;
 
-pub use dir::Dir;
-pub use file::File;
+pub use crate::dir::Dir;
+pub use crate::file::File;
 
 #[doc(hidden)]
 #[proc_macro_hack]

--- a/include_dir_impl/Cargo.toml
+++ b/include_dir_impl/Cargo.toml
@@ -17,8 +17,8 @@ branch = "master"
 repository = "Michael-F-Bryan/include_dir"
 
 [dependencies]
-proc-macro-hack = "0.4"
-syn = "0.14.1"
+proc-macro-hack = "0.5"
+syn = "0.15"
 quote = "0.6.3"
 failure = "0.1.1"
 proc-macro2 = "0.4.4"

--- a/include_dir_impl/Cargo.toml
+++ b/include_dir_impl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
 name = "include_dir_impl"
-version = "0.2.1"
+version = "0.3.0"
 description = "Implementation crate for include_dir"
 license = "MIT"
 readme = "../README.md"

--- a/include_dir_impl/Cargo.toml
+++ b/include_dir_impl/Cargo.toml
@@ -6,6 +6,7 @@ description = "Implementation crate for include_dir"
 license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/Michael-F-Bryan/include_dir"
+edition = "2018"
 
 [badges.appveyor]
 branch = "master"

--- a/include_dir_impl/src/dir.rs
+++ b/include_dir_impl/src/dir.rs
@@ -1,8 +1,9 @@
 use failure::{self, Error, ResultExt};
-use file::File;
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
 use std::path::{Path, PathBuf};
+
+use crate::file::File;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Dir {

--- a/include_dir_impl/src/dir.rs
+++ b/include_dir_impl/src/dir.rs
@@ -5,11 +5,11 @@ use quote::{ToTokens, quote};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Dir {
-    pub root_rel_path: PathBuf,
-    pub abs_path: PathBuf,
-    pub files: Vec<File>,
-    pub dirs: Vec<Dir>,
+pub(crate) struct Dir {
+    root_rel_path: PathBuf,
+    abs_path: PathBuf,
+    files: Vec<File>,
+    dirs: Vec<Dir>,
 }
 
 impl Dir {

--- a/include_dir_impl/src/dir.rs
+++ b/include_dir_impl/src/dir.rs
@@ -1,7 +1,7 @@
 use failure::{self, Error, ResultExt};
 use file::File;
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{ToTokens, quote};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -47,7 +47,7 @@ impl ToTokens for Dir {
         let dirs = &self.dirs;
 
         let tok = quote!{
-            Dir {
+            $crate::Dir {
                 path: #root_rel_path,
                 files: &[#(
                     #files

--- a/include_dir_impl/src/file.rs
+++ b/include_dir_impl/src/file.rs
@@ -1,6 +1,6 @@
 use failure::{Error};
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{ToTokens, quote};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -26,7 +26,7 @@ impl ToTokens for File {
         let abs_path = self.abs_path.display().to_string();
 
         let tok = quote!{
-            File {
+            $crate::File {
                 path: #root_rel_path,
                 contents: include_bytes!(#abs_path),
             }

--- a/include_dir_impl/src/file.rs
+++ b/include_dir_impl/src/file.rs
@@ -4,9 +4,9 @@ use quote::{ToTokens, quote};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct File {
-    pub root_rel_path: PathBuf,
-    pub abs_path: PathBuf,
+pub(crate) struct File {
+    root_rel_path: PathBuf,
+    abs_path: PathBuf,
 }
 
 impl File {

--- a/include_dir_impl/src/lib.rs
+++ b/include_dir_impl/src/lib.rs
@@ -3,18 +3,12 @@
 //! [include_dir!()]: https://github.com/Michael-F-Bryan/include_dir
 
 extern crate proc_macro;
-extern crate proc_macro_hack;
-extern crate failure;
-extern crate proc_macro2;
-extern crate syn;
-extern crate quote;
 
 use proc_macro::TokenStream;
 use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 use syn::{parse_macro_input, LitStr};
 
-use dir::Dir;
 use std::env;
 use std::path::PathBuf;
 
@@ -34,7 +28,7 @@ pub fn include_dir(input: TokenStream) -> TokenStream {
 
     let path = path.canonicalize().expect("Can't normalize the path");
 
-    let dir = Dir::from_disk(&path, &path).expect("Couldn't load the directory");
+    let dir = dir::Dir::from_disk(&path, &path).expect("Couldn't load the directory");
 
     TokenStream::from(quote! {
         #dir


### PR DESCRIPTION
This is built upon #35. It also includes switching the crate to the 2018 edition. I put it in a separate PR because this breaks compatibility with rust versions 1.30.0 and below. I also made a major version bump to make sure consumers of this crate using an older rust won't get broken by a minor version update.