### PR TITLE
Export DirEntry so it can be used in pattern matching

### DIFF
--- a/include_dir/src/globs.rs
+++ b/include_dir/src/globs.rs
@@ -38,13 +38,17 @@ impl<'a> Iterator for Globs<'a> {
     }
 }
 
+/// Entries returned by the Globs iterator
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum DirEntry<'a> {
+    /// A file with its contents stored in a &'static [u8].
     File(File<'a>),
+    /// A directory entry.
     Dir(Dir<'a>),
 }
 
 impl<'a> DirEntry<'a> {
+    /// Get the entries's path
     pub fn path(&self) -> &'a Path {
         match *self {
             DirEntry::File(f) => f.path(),

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -53,6 +53,7 @@ mod globs;
 
 pub use crate::dir::Dir;
 pub use crate::file::File;
+pub use crate::globs::DirEntry;
 
 #[doc(hidden)]
 #[proc_macro_hack]


### PR DESCRIPTION
Currently when looping over a glob you have to extra the path from the returned DirEntry and then re-extract the File or Dir from the root Dir.

It would be nicer to be able to pattern match on the DirEntry which already contains these Files/Dirs so there is no need to reference the original Dir. But the globs module is no public so you cannot directly reference the DirEntry.

This pull request publicly reuses DirEntry effectively exporting it from the crate and allowing the following code to work. It should also now show up in the documentation so you can see what methods are on it without having to dig into the source code or guess form examples.

```rust
    for entry in FILES.find("**").unwrap() {
        if let include_dir::DirEntry::File(file) = entry {
            println!("{}", file.contents_utf8().unwrap());
        }
    }
```