### PR TITLE
Bump the MSRV and migrate to the 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-  - 1.31.0
+  - 1.32.0
   - nightly
 
 cache: cargo

--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -8,6 +8,7 @@ readme = "../README.md"
 keywords = ["assets", "include", "embed", "dir"]
 repository = "https://github.com/Michael-F-Bryan/include_dir"
 categories = ["development-tools", "web-programming", "game-engines"]
+edition = "2018"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/include_dir/src/dir.rs
+++ b/include_dir/src/dir.rs
@@ -1,6 +1,6 @@
 use crate::file::File;
-use glob::{Pattern, PatternError};
 use crate::globs::{DirEntry, Globs};
+use glob::{Pattern, PatternError};
 use std::path::Path;
 
 /// A directory entry.

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -51,8 +51,8 @@ mod dir;
 mod file;
 mod globs;
 
-pub use dir::Dir;
-pub use file::File;
+pub use crate::dir::Dir;
+pub use crate::file::File;
 
 #[doc(hidden)]
 #[proc_macro_hack]

--- a/include_dir_impl/Cargo.toml
+++ b/include_dir_impl/Cargo.toml
@@ -6,6 +6,7 @@ description = "Implementation crate for include_dir"
 license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/Michael-F-Bryan/include_dir"
+edition = "2018"
 
 [badges.appveyor]
 branch = "master"

--- a/include_dir_impl/src/dir.rs
+++ b/include_dir_impl/src/dir.rs
@@ -1,5 +1,5 @@
+use crate::file::File;
 use failure::{self, Error, ResultExt};
-use file::File;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use std::path::{Path, PathBuf};

--- a/include_dir_impl/src/lib.rs
+++ b/include_dir_impl/src/lib.rs
@@ -14,7 +14,7 @@ use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 use syn::{parse_macro_input, LitStr};
 
-use dir::Dir;
+use crate::dir::Dir;
 use std::env;
 use std::path::PathBuf;
 


### PR DESCRIPTION
This fixes the CI failure on `master` and #44.

Note to self: the next release will need to bump the minor version because this is a backwards incompatible change.