### PR TITLE
Cleans up some Rust 2015 style code and updates `include_dir_impl` dependency

### DIFF
--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -25,10 +25,7 @@ repository = "Michael-F-Bryan/include_dir"
 [dependencies]
 glob = "0.3"
 proc-macro-hack = "0.5"
-
-[dependencies.include_dir_impl]
-#path = "../include_dir_impl"
-version = "^0.5.0"
+include_dir_impl = { path = "../include_dir_impl", version = "0.5.1-alpha.0" }
 
 [features]
 default = []

--- a/include_dir/src/dir.rs
+++ b/include_dir/src/dir.rs
@@ -39,7 +39,7 @@ impl<'a> Dir<'a> {
 
     /// Fetch a sub-directory by *exactly* matching its path relative to the
     /// directory included with `include_dir!()`.
-    pub fn get_dir<S: AsRef<Path>>(&self, path: S) -> Option<Dir> {
+    pub fn get_dir<S: AsRef<Path>>(&self, path: S) -> Option<Dir<'_>> {
         let path = path.as_ref();
 
         for dir in self.dirs {
@@ -57,7 +57,7 @@ impl<'a> Dir<'a> {
 
     /// Fetch a sub-directory by *exactly* matching its path relative to the
     /// directory included with `include_dir!()`.
-    pub fn get_file<S: AsRef<Path>>(&self, path: S) -> Option<File> {
+    pub fn get_file<S: AsRef<Path>>(&self, path: S) -> Option<File<'_>> {
         let path = path.as_ref();
 
         for file in self.files {

--- a/include_dir/src/file.rs
+++ b/include_dir/src/file.rs
@@ -30,7 +30,7 @@ impl<'a> File<'a> {
 }
 
 impl<'a> Debug for File<'a> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("File")
             .field("path", &self.path)
             .field("contents", &format!("<{} bytes>", self.contents.len()))

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -35,9 +35,12 @@
 //! - **example:** compile in an example of the embedded directory tree
 
 #![deny(
-    missing_docs,
+    elided_lifetimes_in_paths,
+    future_incompatible,
     missing_copy_implementations,
-    missing_debug_implementations
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
 )]
 
 #[allow(unused_imports)]

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -45,7 +45,7 @@
 extern crate include_dir_impl;
 #[macro_use]
 extern crate proc_macro_hack;
-extern crate glob;
+
 
 mod dir;
 mod file;

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -46,7 +46,6 @@ extern crate include_dir_impl;
 #[macro_use]
 extern crate proc_macro_hack;
 
-
 mod dir;
 mod file;
 mod globs;

--- a/include_dir/tests/integration_test.rs
+++ b/include_dir/tests/integration_test.rs
@@ -4,7 +4,7 @@ extern crate include_dir;
 use include_dir::Dir;
 use std::path::Path;
 
-const PARENT_DIR: Dir = include_dir!(".");
+const PARENT_DIR: Dir<'_> = include_dir!(".");
 
 #[test]
 fn included_all_files() {
@@ -14,7 +14,7 @@ fn included_all_files() {
     validate_directory(PARENT_DIR, root, root);
 }
 
-fn validate_directory(dir: Dir, path: &Path, root: &Path) {
+fn validate_directory(dir: Dir<'_>, path: &Path, root: &Path) {
     for entry in path.read_dir().unwrap() {
         let entry = entry.unwrap().path();
         let entry = entry.strip_prefix(root).unwrap();

--- a/include_dir_impl/src/lib.rs
+++ b/include_dir_impl/src/lib.rs
@@ -2,12 +2,12 @@
 //!
 //! [include_dir!()]: https://github.com/Michael-F-Bryan/include_dir
 
-extern crate failure;
-extern crate proc_macro;
-extern crate proc_macro2;
-extern crate proc_macro_hack;
-extern crate quote;
-extern crate syn;
+
+
+
+
+
+
 
 use proc_macro::TokenStream;
 use proc_macro_hack::proc_macro_hack;

--- a/include_dir_impl/src/lib.rs
+++ b/include_dir_impl/src/lib.rs
@@ -2,12 +2,7 @@
 //!
 //! [include_dir!()]: https://github.com/Michael-F-Bryan/include_dir
 
-
-
-
-
-
-
+extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use proc_macro_hack::proc_macro_hack;


### PR DESCRIPTION
Most of these changes were automatically applied via `cargo fix`

**Changelog**

**[92e6b8f] Fixes cargo fix and cleans whitespace with rustfmt**
cargo fix removed `extern crate proc_macro` despite this
being a [well known exception](https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html?highlight=extern,crate#an-exception) to the 2018 syntax.

**[2543488] Updates include_dir_impl dependency to use path**
We now use the in-repo path and manually specify the
pre-release version.

**[6b5fd0b] Updates codebase to use Rust 2018 idioms**
This commit simply runs `cargo fix --edition-idioms` across the codebase.
There are no hand-edited changes included here.