### PR TITLE
Introduces `search` feature enabled by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ rust:
 cache: cargo
 
 script:
-  - cargo build --all --verbose
-  - cargo test --all --verbose
+  - cargo build --workspace --all-features --verbose
+  - cargo test --workspace --all-features --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: rust
 rust:
   - stable
-  - 1.34.0
+  - 1.40.0
   - nightly
 
 cache: cargo
 
 script:
-  - cargo build --all --all-features --verbose
-  - cargo test --all --all-features --verbose
+  - cargo build --workspace --all-features --verbose
+  - cargo test --workspace --all-features --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ rust:
 cache: cargo
 
 script:
-  - cargo build --workspace --all-features --verbose
-  - cargo test --workspace --all-features --verbose
+  - cargo build --all --all-features --verbose
+  - cargo test --all --all-features --verbose

--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ let body = lib_rs.contents_utf8().unwrap();
 assert!(body.contains("SOME_INTERESTING_STRING"));
 
 // you can search for files (and directories) using glob patterns
-let glob = "**/*.rs";
-for entry in PROJECT_DIR.find(glob).unwrap() {
-    println!("Found {}", entry.path().display());
+#[cfg(feature = "search")]
+{
+    let glob = "**/*.rs";
+    for entry in PROJECT_DIR.find(glob).unwrap() {
+        println!("Found {}", entry.path().display());
+    }
 }
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,10 +28,10 @@ install:
 test_script:
   # we don't run the "test phase" when doing deploys
   - if [%APPVEYOR_REPO_TAG%]==[false] (
-      cargo build --target %TARGET% &&
-      cargo build --target %TARGET% --release &&
-      cargo test --target %TARGET% &&
-      cargo test --target %TARGET% --release
+      cargo build --workspace --all-features --target %TARGET% &&
+      cargo build --workspace --all-features --target %TARGET% --release &&
+      cargo test --workspace --all-features --target %TARGET% &&
+      cargo test --workspace --all-features --target %TARGET% --release
     )
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 
 environment:
   global:
-    RUST_VERSION: stable
+    RUST_VERSION: 1.34.0
 
     CRATE_NAME: include_dir
 
@@ -11,6 +11,11 @@ environment:
     # MSVC
     - TARGET: i686-pc-windows-msvc
     - TARGET: x86_64-pc-windows-msvc
+    # MSVC (nightly)
+    - TARGET: i686-pc-windows-msvc
+      RUST_VERSION: nightly
+    - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: nightly
 
 install:
   - ps: >-
@@ -28,10 +33,10 @@ install:
 test_script:
   # we don't run the "test phase" when doing deploys
   - if [%APPVEYOR_REPO_TAG%]==[false] (
-      cargo build --workspace --all-features --target %TARGET% &&
-      cargo build --workspace --all-features --target %TARGET% --release &&
-      cargo test --workspace --all-features --target %TARGET% &&
-      cargo test --workspace --all-features --target %TARGET% --release
+      cargo build --all --all-features --target %TARGET% &&
+      cargo build --all --all-features --target %TARGET% --release &&
+      cargo test --all --all-features --target %TARGET% &&
+      cargo test --all --all-features --target %TARGET% --release
     )
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 
 environment:
   global:
-    RUST_VERSION: 1.34.0
+    RUST_VERSION: 1.40.0
 
     CRATE_NAME: include_dir
 
@@ -33,10 +33,10 @@ install:
 test_script:
   # we don't run the "test phase" when doing deploys
   - if [%APPVEYOR_REPO_TAG%]==[false] (
-      cargo build --all --all-features --target %TARGET% &&
-      cargo build --all --all-features --target %TARGET% --release &&
-      cargo test --all --all-features --target %TARGET% &&
-      cargo test --all --all-features --target %TARGET% --release
+      cargo build --workspace --all-features --target %TARGET% &&
+      cargo build --workspace --all-features --target %TARGET% --release &&
+      cargo test --workspace --all-features --target %TARGET% &&
+      cargo test --workspace --all-features --target %TARGET% --release
     )
 
 cache:

--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -23,10 +23,11 @@ branch = "master"
 repository = "Michael-F-Bryan/include_dir"
 
 [dependencies]
-glob = "0.3"
+glob = { version = "0.3", optional = true }
 proc-macro-hack = "0.5"
 include_dir_impl = { path = "../include_dir_impl", version = "0.5.1-alpha.0" }
 
 [features]
-default = []
+default = [ "search" ]
 example-output = []
+search = [ "glob" ]

--- a/include_dir/src/dir.rs
+++ b/include_dir/src/dir.rs
@@ -1,6 +1,4 @@
 use crate::file::File;
-use crate::globs::{DirEntry, Globs};
-use glob::{Pattern, PatternError};
 use std::path::Path;
 
 /// A directory entry.
@@ -73,19 +71,5 @@ impl<'a> Dir<'a> {
         }
 
         None
-    }
-
-    /// Search for a file or directory with a glob pattern.
-    pub fn find(&self, glob: &str) -> Result<impl Iterator<Item = DirEntry<'a>>, PatternError> {
-        let pattern = Pattern::new(glob)?;
-
-        Ok(Globs::new(pattern, *self))
-    }
-
-    pub(crate) fn dir_entries(&self) -> impl Iterator<Item = DirEntry<'a>> {
-        let files = self.files().iter().map(|f| DirEntry::File(*f));
-        let dirs = self.dirs().iter().map(|d| DirEntry::Dir(*d));
-
-        files.chain(dirs)
     }
 }

--- a/include_dir/src/globs.rs
+++ b/include_dir/src/globs.rs
@@ -1,12 +1,28 @@
 use crate::dir::Dir;
 use crate::file::File;
-use glob::Pattern;
+use glob::{Pattern, PatternError};
 use std::path::Path;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Globs<'a> {
     stack: Vec<DirEntry<'a>>,
     pattern: Pattern,
+}
+
+impl<'a> Dir<'a> {
+    /// Search for a file or directory with a glob pattern.
+    pub fn find(&self, glob: &str) -> Result<impl Iterator<Item = DirEntry<'a>>, PatternError> {
+        let pattern = Pattern::new(glob)?;
+
+        Ok(Globs::new(pattern, *self))
+    }
+
+    pub(crate) fn dir_entries(&self) -> impl Iterator<Item = DirEntry<'a>> {
+        let files = self.files().iter().map(|f| DirEntry::File(*f));
+        let dirs = self.dirs().iter().map(|d| DirEntry::Dir(*d));
+
+        files.chain(dirs)
+    }
 }
 
 impl<'a> Globs<'a> {

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -69,4 +69,4 @@ pub use include_dir_impl::include_dir;
 
 /// Example the output generated when running `include_dir!()` on itself.
 #[cfg(feature = "example-output")]
-pub static GENERATED_EXAMPLE: Dir = include_dir!(".");
+pub static GENERATED_EXAMPLE: Dir<'_> = include_dir!(".");

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -20,10 +20,13 @@
 //! let body = lib_rs.contents_utf8().unwrap();
 //! assert!(body.contains("SOME_INTERESTING_STRING"));
 //!
-//! // you can search for files (and directories) using glob patterns
-//! let glob = "**/*.rs";
-//! for entry in PROJECT_DIR.find(glob).unwrap() {
-//!     println!("Found {}", entry.path().display());
+//! // if you enable the `search` feature, you can for files (and directories) using glob patterns
+//! #[cfg(feature = "search")]
+//! {
+//!     let glob = "**/*.rs";
+//!     for entry in PROJECT_DIR.find(glob).unwrap() {
+//!         println!("Found {}", entry.path().display());
+//!     }
 //! }
 //! ```
 //!
@@ -51,10 +54,13 @@ extern crate proc_macro_hack;
 
 mod dir;
 mod file;
+
+#[cfg(feature = "search")]
 mod globs;
 
 pub use crate::dir::Dir;
 pub use crate::file::File;
+#[cfg(feature = "search")]
 pub use crate::globs::DirEntry;
 
 #[doc(hidden)]

--- a/include_dir/tests/integration_test.rs
+++ b/include_dir/tests/integration_test.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate include_dir;
-
-use include_dir::Dir;
+use include_dir::{include_dir, Dir};
 use std::path::Path;
 
 const PARENT_DIR: Dir<'_> = include_dir!(".");


### PR DESCRIPTION
Resolves #42 

**[4c9f9d4] Introduces `search` feature enabled by default**

This change moves the filesystem search functionality behind a feature
flag so that consuming libraries can opt-out of glob if they do not need
it.

For example, users using `include_dir` to serve embedded assets for a game
or a webserver likely know the exact paths of the files they want to
serve.

1. The `search` feature is enabled by default for backwards compatibility.
2. `Dir.find`, the `globs` module, and the `glob` dependency are now
   gated behind the `search` feature.
3. `glob` is now an optional dependency
4. This change also updates the CI configuration to test all features in
   case new ones are introduced in the future