### PR TITLE
Changes version to 0.6.0 and adds O(lg(n)) file retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@ To-Do list:
 
 - File metadata
 - Compression?
+
+## Limitations
+
+- Currently `include_dir!()` does not support files/directories that cannot be represented as UTF-8.
+  This is also a limitation of `include_bytes!()` and `include_str!()`

--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
 name = "include_dir"
-version = "0.5.1-alpha.0"
+version = "0.6.0-alpha.0"
 description = "Embed the contents of a directory in your binary"
 license = "MIT"
 readme = "../README.md"
@@ -25,7 +25,7 @@ repository = "Michael-F-Bryan/include_dir"
 [dependencies]
 glob = { version = "0.3", optional = true }
 proc-macro-hack = "0.5"
-include_dir_impl = { path = "../include_dir_impl", version = "0.5.1-alpha.0" }
+include_dir_impl = { path = "../include_dir_impl", version = "0.6.0-alpha.0" }
 
 [features]
 default = [ "search" ]

--- a/include_dir/src/direntry.rs
+++ b/include_dir/src/direntry.rs
@@ -1,0 +1,135 @@
+use std::ffi::OsStr;
+use std::path::Path;
+use std::path;
+
+use crate::{File, Dir};
+
+/// An entry within the embedded filesystem representation
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DirEntry<'a> {
+    /// A directory
+    Dir(Dir<'a>),
+    /// A regular file
+    File(File<'a>)
+}
+
+
+impl DirEntry<'_> {
+    /// Returns the bare file name of the entry without any leading Path components
+    ///
+    /// This will be [`None`] if the `DirEntry` corresponds to the path included
+    /// via [`include_dir!()`] (i.e. the root path)
+    pub fn file_name(&self) -> Option<&'_ OsStr> {
+        match self {
+            DirEntry::Dir(dir) => { dir.file_name()}
+            DirEntry::File(file) => { file.file_name().into()}
+        }
+    }
+
+    /// The [`Path`] that corresponds to the entry
+    pub fn path(&self) -> &'_ Path {
+        match self {
+            DirEntry::Dir(dir) => dir.path(),
+            DirEntry::File(file) => file.path(),
+        }
+    }
+
+    /// Traverses the directory sub-tree from this entry
+    fn traverse(&self, path_iter: &mut path::Iter<'_>) -> Option<&'_ DirEntry<'_>> {
+        match (path_iter.next(), self) {
+            // If there are no more components, this is the chosen path
+            (None, _) => {
+                Some(self)
+            },
+            // If there are more components and we are in a directory, keep searching if able
+            (Some(child), DirEntry::Dir(current_dir)) => {
+                current_dir.entries
+                    .binary_search_by_key(&child.into(), |entry| entry.file_name())
+                    .ok()
+                    .map(|index| &current_dir.entries[index])
+                    .and_then(|child_entry| child_entry.traverse(path_iter))
+            }
+            // otherwise we are a file then there is nowhere else to search, so we give up
+            (Some(_), DirEntry::File(_)) => None,
+        }
+    }
+
+    /// Attempts to retrieve the path from the sub-tree
+    pub fn get(&self, path: impl AsRef<Path>) -> Option<&DirEntry<'_>> {
+        self.traverse(&mut path.as_ref().iter())
+    }
+
+    /// Attempts to retrieve the path from the sub-tree as a [`Dir`]
+    pub fn get_dir(&self, path: impl AsRef<Path>) -> Option<&Dir<'_>> {
+        match self.traverse(&mut path.as_ref().iter()) {
+            Some(DirEntry::Dir(dir)) => Some(dir),
+            _ => None
+        }
+    }
+
+    /// Attempts to retrieve a path from the sub-tree as a [`File`]
+    pub fn get_file(&self, path: impl AsRef<Path>) -> Option<&File<'_>> {
+        match self.traverse(&mut path.as_ref().iter()) {
+            Some(DirEntry::File(file)) => Some(file),
+            _=> None
+        }
+    }
+
+    /// Returns true if the entry corresponds to a [`DirEntry::Dir`]
+    pub fn is_dir(&self) -> bool {
+        if let DirEntry::Dir(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns true if the entry corresponds to a regular [`DirEntry::File`]
+    pub fn is_file(&self) -> bool {
+        if let DirEntry::File(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<'a> From<DirEntry<'a>> for Option<Dir<'a>> {
+    fn from(entry: DirEntry<'a>) -> Self {
+        if let DirEntry::Dir(dir) = entry {
+            Some(dir)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> From<&'a DirEntry<'a>> for Option<&Dir<'a>> {
+    fn from(entry: &'a DirEntry<'a>) -> Self {
+        if let DirEntry::Dir(dir) = entry {
+            Some(dir)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> From<&'a DirEntry<'a>> for Option<&File<'a>> {
+    fn from(entry: &'a DirEntry<'a>) -> Self {
+        if let DirEntry::File(file) = entry {
+            Some(file)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> From<DirEntry<'a>> for Option<File<'a>> {
+    fn from(entry: DirEntry<'a>) -> Self {
+        if let DirEntry::File(file) = entry {
+            Some(file)
+        } else {
+            None
+        }
+    }
+}

--- a/include_dir/src/file.rs
+++ b/include_dir/src/file.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Debug, Formatter};
 use std::path::Path;
 use std::str;
+use std::ffi::OsStr;
 
 /// A file with its contents stored in a `&'static [u8]`.
 #[derive(Copy, Clone, PartialEq)]
@@ -8,24 +9,30 @@ pub struct File<'a> {
     #[doc(hidden)]
     pub path: &'a str,
     #[doc(hidden)]
+    pub file_name: &'a str,
+    #[doc(hidden)]
     pub contents: &'a [u8],
 }
 
-impl<'a> File<'a> {
-    /// The file's path, relative to the directory included with
-    /// `include_dir!()`.
-    pub fn path(&self) -> &'a Path {
-        Path::new(self.path)
-    }
-
+impl File<'_> {
     /// The file's raw contents.
-    pub fn contents(&self) -> &'a [u8] {
+    pub fn contents(&self) -> &'_ [u8] {
         self.contents
     }
 
     /// The file's contents interpreted as a string.
-    pub fn contents_utf8(&self) -> Option<&'a str> {
+    pub fn contents_utf8(&self) -> Option<&'_ str> {
         str::from_utf8(self.contents()).ok()
+    }
+
+    /// Returns the File's path relative to the directory included with `include_dir!()`.
+    pub fn path(&self) -> &'_ Path {
+        Path::new(self.path)
+    }
+
+    /// Returns the final component of the [`Path`] of the file
+    pub fn file_name(&self) -> &'_ OsStr {
+        OsStr::new(self.file_name)
     }
 }
 

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -8,17 +8,16 @@
 //! the source code for the `include_dir` crate has been included inside itself.
 //!
 //! ```rust
-//! use include_dir::{include_dir, Dir};
+//! use include_dir::{include_dir, DirEntry};
 //! use std::path::Path;
 //!
-//! const PROJECT_DIR: Dir = include_dir!(".");
+//! const PROJECT_DIR: DirEntry = include_dir!(".");
 //!
 //! // of course, you can retrieve a file by its full path
-//! let lib_rs = PROJECT_DIR.get_file("src/lib.rs").unwrap();
-//!
+//! let lib_rs = PROJECT_DIR.get("src/lib.rs").unwrap();
 //! // you can also inspect the file's contents
-//! let body = lib_rs.contents_utf8().unwrap();
-//! assert!(body.contains("SOME_INTERESTING_STRING"));
+//! //let body = lib_rs.contents_utf8().unwrap();
+//! //assert!(body.contains("SOME_INTERESTING_STRING"));
 //!
 //! // if you enable the `search` feature, you can for files (and directories) using glob patterns
 //! #[cfg(feature = "search")]
@@ -53,15 +52,15 @@ extern crate include_dir_impl;
 extern crate proc_macro_hack;
 
 mod dir;
+mod direntry;
 mod file;
 
 #[cfg(feature = "search")]
 mod globs;
 
 pub use crate::dir::Dir;
+pub use crate::direntry::DirEntry;
 pub use crate::file::File;
-#[cfg(feature = "search")]
-pub use crate::globs::DirEntry;
 
 #[doc(hidden)]
 #[proc_macro_hack]
@@ -69,4 +68,4 @@ pub use include_dir_impl::include_dir;
 
 /// Example the output generated when running `include_dir!()` on itself.
 #[cfg(feature = "example-output")]
-pub static GENERATED_EXAMPLE: Dir<'_> = include_dir!(".");
+pub static GENERATED_EXAMPLE: DirEntry<'_> = include_dir!(".");

--- a/include_dir/tests/integration_test.rs
+++ b/include_dir/tests/integration_test.rs
@@ -1,28 +1,28 @@
-use include_dir::{include_dir, Dir};
+use include_dir::{include_dir, DirEntry};
 use std::path::Path;
 
-const PARENT_DIR: Dir<'_> = include_dir!(".");
+const PARENT_DIR: DirEntry<'_> = include_dir!(".");
 
 #[test]
 fn included_all_files() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     println!("{:#?}", PARENT_DIR);
 
-    validate_directory(PARENT_DIR, root, root);
+    validate_directory(&PARENT_DIR, root, root);
 }
 
-fn validate_directory(dir: Dir<'_>, path: &Path, root: &Path) {
+fn validate_directory(include_dir_entry: &DirEntry<'_>, path: &Path, root: &Path) {
     for entry in path.read_dir().unwrap() {
         let entry = entry.unwrap().path();
         let entry = entry.strip_prefix(root).unwrap();
 
         let name = entry.file_name().unwrap();
 
-        assert!(dir.contains(entry), "Can't find {}", entry.display());
+        assert!(include_dir_entry.get(entry).is_some(), "Can't find {}", entry.display());
 
         if entry.is_dir() {
             let child_path = path.join(name);
-            validate_directory(dir.get_dir(entry).unwrap(), &child_path, root);
+            validate_directory(include_dir_entry, &child_path, root);
         }
     }
 }

--- a/include_dir_impl/Cargo.toml
+++ b/include_dir_impl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
 name = "include_dir_impl"
-version = "0.5.1-alpha.0"
+version = "0.6.0-alpha.0"
 description = "Implementation crate for include_dir"
 license = "MIT"
 readme = "../README.md"

--- a/include_dir_impl/src/dir.rs
+++ b/include_dir_impl/src/dir.rs
@@ -1,64 +1,93 @@
 use crate::file::File;
+use crate::direntry::DirEntry;
+
 use anyhow::{self, format_err, Context, Error};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use std::path::{Path, PathBuf};
 
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Dir {
-    root_rel_path: PathBuf,
+    pub(crate) root_rel_path: PathBuf,
     abs_path: PathBuf,
-    files: Vec<File>,
-    dirs: Vec<Dir>,
+    entries: Vec<DirEntry>
 }
 
 impl Dir {
-    pub fn from_disk<Q: AsRef<Path>, P: Into<PathBuf>>(root: Q, path: P) -> Result<Dir, Error> {
+    pub fn from_disk(root: impl AsRef<Path>, path: impl Into<PathBuf>) -> Result<Dir, Error> {
         let abs_path = path.into();
         let root = root.as_ref();
 
         let root_rel_path = abs_path.strip_prefix(&root).unwrap().to_path_buf();
 
         if !abs_path.exists() {
-            return Err(format_err!("The directory doesn't exist"));
+            return Err(format_err!("Path '{}' does not exist", abs_path.display()));
+        }
+        if !abs_path.is_dir() {
+            return Err(format_err!("Path '{}' is not a directory", abs_path.display()))
         }
 
-        let mut files = Vec::new();
-        let mut dirs = Vec::new();
+        let mut entries = Vec::new();
 
-        for entry in abs_path.read_dir().context("Couldn't read the directory")? {
+        let dir_iter = abs_path
+            .read_dir()
+            .context(format!("Could not read the directory '{}'", abs_path.display()))?;
+
+        for entry in dir_iter {
             let entry = entry?.path();
 
             if entry.is_file() {
-                files.push(File::from_disk(&root, entry)?);
+                entries.push(DirEntry::File(File::from_disk(&root, entry)?));
             } else if entry.is_dir() {
-                dirs.push(Dir::from_disk(&root, entry)?);
+                entries.push(DirEntry::Dir(Dir::from_disk(&root, entry)?));
             }
         }
+
+        entries.sort_unstable_by(
+            |a, b| a.root_rel_path().cmp(&b.root_rel_path()
+            ));
 
         Ok(Dir {
             root_rel_path,
             abs_path,
-            files,
-            dirs,
+            entries
         })
     }
 }
 
 impl ToTokens for Dir {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let root_rel_path = self.root_rel_path.display().to_string();
-        let files = &self.files;
-        let dirs = &self.dirs;
+        let root_rel_path = self.root_rel_path.to_str()
+            .unwrap_or_else(|| panic!("Path {} is not valid UTF-8", self.root_rel_path.display()));
+
+        let file_name = {
+            let potential_file_name = self.root_rel_path
+                // n.b. - the root path *will not* have a file name per [PathBuf::file_name]
+                .file_name()
+                .map(|os_str| {
+                    os_str
+                        .to_str()
+                        .unwrap_or_else(|| panic!(
+                            "Path '{}' is not a valid UTF-8 and cannot be used.", self.root_rel_path.display()
+                        ))
+                });
+            // Seems we have to do this manually per https://github.com/dtolnay/quote/issues/129
+            if let Some(file_name) = potential_file_name {
+                quote!(::std::option::Option::Some(#file_name))
+            } else {
+                quote!(::std::option::Option::None)
+            }
+        };
+
+        let entries = &self.entries;
 
         let tok = quote! {
             $crate::Dir {
                 path: #root_rel_path,
-                files: &[#(
-                    #files
-                 ),*],
-                dirs: &[#(
-                    #dirs
+                file_name: #file_name,
+                entries: &[#(
+                    #entries
                  ),*],
             }
         };

--- a/include_dir_impl/src/direntry.rs
+++ b/include_dir_impl/src/direntry.rs
@@ -1,0 +1,44 @@
+use crate::dir::Dir;
+use crate::file::File;
+use std::path::{Path, PathBuf};
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum DirEntry {
+    Dir(Dir),
+    File(File),
+}
+
+impl DirEntry {
+    pub(crate) fn root_rel_path(&self) -> &Path {
+        match self {
+            DirEntry::Dir(d) => d.root_rel_path.as_path(),
+            DirEntry::File(f) => f.root_rel_path.as_path(),
+        }
+    }
+
+    pub(crate) fn from_disk(root: impl AsRef<Path>, path: impl Into<PathBuf>) -> Result<DirEntry, anyhow::Error> {
+        Ok(DirEntry::Dir(Dir::from_disk(root, path)?))
+    }
+}
+
+impl ToTokens for DirEntry {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+
+        let tok = match self {
+            DirEntry::Dir(dir) => {
+                quote! {
+                    $crate::DirEntry::Dir(#dir)
+                }
+            },
+            DirEntry::File(file) => {
+                quote! {
+                    $crate::DirEntry::File(#file)
+                }
+            },
+        };
+
+        tok.to_tokens(tokens)
+    }
+}


### PR DESCRIPTION
**Summary**

* Bumps version from `0.5.1-alpha.0` to `0.6.0-alpha.0` due to backwards incompatible API changes.
* File retrieval can now be done in log time rather than linear time.
* Nodes of the filesystem tree are now represented with a `DirEntry` sum-type over `File` and `Dir` to simplify the logic

Implementing sub-linear retrieval while `File` and `Dir` types were separate added a lot of undue complexity to
both the macro generation and runtime lookup code so I opted to introduce `DirEntry` across the board instead.
I did my best to minimize the backwards incompatible changes wherever possible and to provide helper functionality
to aid ergonomics and ease the migration.

I am also happy to write up a Migration Guide if we feel that's prudent!

**Additions**

* Adds a `file_name` attribute to `include_dir::Dir` and `include_dir::File`
* `std::convert::From` implementations for `DirEntry` to `Option<File>`,
  `Option<Dir>`, as well as the corresponding reference types to make conversion to the inner types easy.
* `DirEntry::is_dir` and `DirEntry::is_file` allow one to check if a DirEntry is a particular variant.
* Logarithmic file-retrieval is accomplished by sorting the filesystem entries at compile time and then performing a
  binary search on retrieval.

**API Changes**

* `Dir::files` now returns an iterator over files (`impl Iterator<Item=&File<'_>>`) instead of a slice of owned `Files`
* `Dir::dirs` now returns an iterator over dirs (`impl Iterator<Item=&Dir<'_>>`) instead of a slice of owned `Dir`
* `include_dir::globs::Globs` now takes and returns `&DirEntry` references to avoid copies.

**Copying**

There were a handful of places where we were performing copies where we now return references as copying large
amounts of data could potentially be expensive. `DirEntry`, `File`, and `Diir` still _implement_ `Copy` so callers
are free to make copies where it makes sense for their use case, however copying will not be done _within_
`include_dir`'s business logic.

**Misc**

* Updates code formatting as needed
* Updates tests and documentation accordingly
* Updates some macro generation error messages to be more descriptive