### PR TITLE
Relax returned lifetimes of get_dir and get_file

### DIFF
--- a/include_dir/src/dir.rs
+++ b/include_dir/src/dir.rs
@@ -37,7 +37,7 @@ impl<'a> Dir<'a> {
 
     /// Fetch a sub-directory by *exactly* matching its path relative to the
     /// directory included with `include_dir!()`.
-    pub fn get_dir<S: AsRef<Path>>(&self, path: S) -> Option<Dir<'_>> {
+    pub fn get_dir<S: AsRef<Path>>(&self, path: S) -> Option<Dir<'a>> {
         let path = path.as_ref();
 
         for dir in self.dirs {
@@ -55,7 +55,7 @@ impl<'a> Dir<'a> {
 
     /// Fetch a sub-directory by *exactly* matching its path relative to the
     /// directory included with `include_dir!()`.
-    pub fn get_file<S: AsRef<Path>>(&self, path: S) -> Option<File<'_>> {
+    pub fn get_file<S: AsRef<Path>>(&self, path: S) -> Option<File<'a>> {
         let path = path.as_ref();
 
         for file in self.files {


### PR DESCRIPTION
Prior to this change, the elided lifetime `'_` would be constrained to at most the lifetime of the `&self` reference _or_ the internal lifetime `'a`, when instead it could just be `'a`.

If `&self` isn't actually behind a static, but `'a: 'static`, the old behavior leads to some rather puzzling lifetime errors.