### PR TITLE
Exclude a fixed set of files. Towards https://github.com/Michael-F-Br…

### DIFF
--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -25,7 +25,7 @@ repository = "Michael-F-Bryan/include_dir"
 [dependencies]
 glob = { version = "0.3", optional = true }
 proc-macro-hack = "0.5"
-include_dir_impl = "=0.6.0"
+include_dir_impl = { path="../include_dir_impl" }
 
 [features]
 default = [ "search" ]

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -43,7 +43,7 @@
     missing_copy_implementations,
     missing_debug_implementations,
     missing_docs,
-    rust_2018_idioms,
+    rust_2018_idioms
 )]
 
 #[allow(unused_imports)]

--- a/include_dir_impl/src/file.rs
+++ b/include_dir_impl/src/file.rs
@@ -1,6 +1,6 @@
-use anyhow::Error;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -10,13 +10,20 @@ pub(crate) struct File {
 }
 
 impl File {
-    pub fn from_disk<Q: AsRef<Path>, P: Into<PathBuf>>(root: Q, path: P) -> Result<File, Error> {
+    pub fn from_disk<Q: AsRef<Path>, P: Into<PathBuf>>(
+        root: Q,
+        path: P,
+        exclude: &HashSet<String>,
+    ) -> Option<File> {
         let abs_path = path.into();
         let root = root.as_ref();
 
         let root_rel_path = abs_path.strip_prefix(&root).unwrap().to_path_buf();
+        if exclude.contains(&root_rel_path.to_string_lossy().to_string()) {
+            return None;
+        }
 
-        Ok(File {
+        Some(File {
             abs_path,
             root_rel_path,
         })

--- a/include_dir_impl/src/lib.rs
+++ b/include_dir_impl/src/lib.rs
@@ -7,21 +7,39 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use proc_macro_hack::proc_macro_hack;
 use quote::quote;
-use syn::{parse_macro_input, LitStr};
+use syn::parse::{Parse, ParseStream, Result};
+use syn::punctuated::Punctuated;
+use syn::{parse_macro_input, LitStr, Token};
 
 use crate::dir::Dir;
+use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
 
 mod dir;
 mod file;
 
+struct Args {
+    dir: String,
+    exclude: HashSet<String>,
+}
+
+impl Parse for Args {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let strings = Punctuated::<LitStr, Token![,]>::parse_terminated(input)?;
+        let mut iter = strings.into_iter();
+        let dir = iter.next().unwrap().value();
+        let exclude = iter.map(|x| x.value()).collect();
+        Ok(Args { dir, exclude })
+    }
+}
+
 #[proc_macro_hack]
 pub fn include_dir(input: TokenStream) -> TokenStream {
-    let input: LitStr = parse_macro_input!(input as LitStr);
+    let args = parse_macro_input!(input as Args);
     let crate_root = env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    let path = PathBuf::from(crate_root).join(input.value());
+    let path = PathBuf::from(crate_root).join(args.dir);
 
     if !path.exists() {
         panic!("\"{}\" doesn't exist", path.display());
@@ -29,7 +47,7 @@ pub fn include_dir(input: TokenStream) -> TokenStream {
 
     let path = path.canonicalize().expect("Can't normalize the path");
 
-    let dir = Dir::from_disk(&path, &path).expect("Couldn't load the directory");
+    let dir = Dir::from_disk(&path, &path, &args.exclude).expect("Couldn't load the directory");
 
     TokenStream::from(quote! {
         #dir


### PR DESCRIPTION
…yan/include_dir/issues/13

This is just a draft. I wanted to get some feedback on what the API for excluding should look like. Right now it's just `include_dir!("path", "exclude1", "exclude2", ...)`. Maybe it should be `include_dir!("path", exclude=["exclude1", "exclude2", ...])`? I'm extremely new to proc macros and `syn`, but I think I can figure it out.

Once the API is settled, I'll add better error handling, update docs, and add a test.

Thanks!
-Dustin