### PR TITLE
Add a macro which includes a dir from `OUT_DIR`

### DIFF
--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -25,7 +25,7 @@ repository = "Michael-F-Bryan/include_dir"
 [dependencies]
 glob = { version = "0.3", optional = true }
 proc-macro-hack = "0.5"
-include_dir_impl = "=0.6.0"
+include_dir_impl = { path = "../include_dir_impl", version = "=0.6.1-alpha.0" }
 
 [features]
 default = [ "search" ]

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -67,6 +67,10 @@ pub use crate::globs::DirEntry;
 #[proc_macro_hack]
 pub use include_dir_impl::include_dir;
 
+#[doc(hidden)]
+#[proc_macro_hack]
+pub use include_dir_impl::include_dir_from_out_dir;
+
 /// Example the output generated when running `include_dir!()` on itself.
 #[cfg(feature = "example-output")]
 pub static GENERATED_EXAMPLE: Dir<'_> = include_dir!(".");

--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -4,8 +4,13 @@
 //! # Examples
 //!
 //! The `include_dir!()` macro will include a directory **relative to the
-//! project root** (using the `CARGO_MANIFEST_DIR` variable), in this example
-//! the source code for the `include_dir` crate has been included inside itself.
+//! project root** (using the `CARGO_MANIFEST_DIR` variable).
+//!
+//! The `include_dir_from_out_dir!()` macro will include a directory relative to
+//! the build script output directory (using the `OUT_DIR` variable).
+//!
+//! In this example, the source code for the `include_dir` crate has been
+//! included inside itself.
 //!
 //! ```rust
 //! use include_dir::{include_dir, Dir};
@@ -63,11 +68,13 @@ pub use crate::file::File;
 #[cfg(feature = "search")]
 pub use crate::globs::DirEntry;
 
-#[doc(hidden)]
+/// Includes a directory relative to the project root
+/// (using the `CARGO_MANIFEST_DIR` variable).
 #[proc_macro_hack]
 pub use include_dir_impl::include_dir;
 
-#[doc(hidden)]
+/// Includes a directory relative to the build script output directory
+/// (using the `OUT_DIR` variable).
 #[proc_macro_hack]
 pub use include_dir_impl::include_dir_from_out_dir;
 

--- a/include_dir_impl/src/lib.rs
+++ b/include_dir_impl/src/lib.rs
@@ -18,10 +18,19 @@ mod file;
 
 #[proc_macro_hack]
 pub fn include_dir(input: TokenStream) -> TokenStream {
-    let input: LitStr = parse_macro_input!(input as LitStr);
-    let crate_root = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let root = env::var("CARGO_MANIFEST_DIR").unwrap();
+    include_dir_from_root(root, input)
+}
 
-    let path = PathBuf::from(crate_root).join(input.value());
+#[proc_macro_hack]
+pub fn include_dir_from_out_dir(input: TokenStream) -> TokenStream {
+    let root = env::var("OUT_DIR").unwrap();
+    include_dir_from_root(root, input)
+}
+
+fn include_dir_from_root(root: String, input: TokenStream) -> TokenStream {
+    let input: LitStr = parse_macro_input!(input as LitStr);
+    let path = PathBuf::from(root).join(input.value());
 
     if !path.exists() {
         panic!("\"{}\" doesn't exist", path.display());

--- a/include_dir_impl/src/lib.rs
+++ b/include_dir_impl/src/lib.rs
@@ -24,7 +24,8 @@ pub fn include_dir(input: TokenStream) -> TokenStream {
 
 #[proc_macro_hack]
 pub fn include_dir_from_out_dir(input: TokenStream) -> TokenStream {
-    let root = env::var_os("OUT_DIR").unwrap();
+    let root = env::var_os("OUT_DIR")
+        .unwrap_or_else(|| panic!("OUT_DIR environment variable is not defined"));
     include_dir_from_root(root, input)
 }
 

--- a/include_dir_impl/src/lib.rs
+++ b/include_dir_impl/src/lib.rs
@@ -10,25 +10,25 @@ use quote::quote;
 use syn::{parse_macro_input, LitStr};
 
 use crate::dir::Dir;
-use std::env;
 use std::path::PathBuf;
+use std::{env, ffi::OsString};
 
 mod dir;
 mod file;
 
 #[proc_macro_hack]
 pub fn include_dir(input: TokenStream) -> TokenStream {
-    let root = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let root = env::var_os("CARGO_MANIFEST_DIR").unwrap();
     include_dir_from_root(root, input)
 }
 
 #[proc_macro_hack]
 pub fn include_dir_from_out_dir(input: TokenStream) -> TokenStream {
-    let root = env::var("OUT_DIR").unwrap();
+    let root = env::var_os("OUT_DIR").unwrap();
     include_dir_from_root(root, input)
 }
 
-fn include_dir_from_root(root: String, input: TokenStream) -> TokenStream {
+fn include_dir_from_root(root: OsString, input: TokenStream) -> TokenStream {
     let input: LitStr = parse_macro_input!(input as LitStr);
     let path = PathBuf::from(root).join(input.value());
 


### PR DESCRIPTION
This PR adds a new macro which resolves the path relative to `OUT_DIR` environment variable, as opposed to `CARGO_MANIFEST_DIR`.

This is useful for crates which use a build script (`build.rs`) to generate some files and wish to include them in the binary. `OUT_DIR` is the only directory where the build script should write files ([reference](https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script)).

I switched `env::var` to `env:var_os` to remove the roundtrip `OsString -> Unicode -> OsString`. The macros should now work even if the project path is not a valid Unicode string.

Resolves #55