### PR TITLE
Support recursive extraction

### DIFF
--- a/include_dir/tests/integration_test.rs
+++ b/include_dir/tests/integration_test.rs
@@ -9,7 +9,7 @@ fn included_all_files() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     println!("{:#?}", PARENT_DIR);
 
-    validate_directory(PARENT_DIR, root, root);
+    validate_included(PARENT_DIR, root, root);
 }
 
 #[test]
@@ -26,11 +26,11 @@ fn extract_all_files() {
     let root = tmpdir.path();
     PARENT_DIR.extract(root).unwrap();
 
-    validate_directory(PARENT_DIR, root, root);
+    validate_extracted(PARENT_DIR, root);
 }
 
-// TODO this needs to check that each file in the directory is present rather than checking that each extracted file is in the directory!
-fn validate_directory(dir: Dir<'_>, path: &Path, root: &Path) {
+// Validates that all files on the filesystem exist in the inclusion
+fn validate_included(dir: Dir<'_>, path: &Path, root: &Path) {
     for entry in path.read_dir().unwrap() {
         let entry = entry.unwrap().path();
         let entry = entry.strip_prefix(root).unwrap();
@@ -41,7 +41,23 @@ fn validate_directory(dir: Dir<'_>, path: &Path, root: &Path) {
 
         if entry.is_dir() {
             let child_path = path.join(name);
-            validate_directory(dir.get_dir(entry).unwrap(), &child_path, root);
+            validate_included(dir.get_dir(entry).unwrap(), &child_path, root);
         }
+    }
+}
+
+// Validates that all files in the inclusion were extracted to the filesystem
+fn validate_extracted(dir: Dir, path: &Path) {
+    // Check if all the subdirectories exist, recursing on each
+    for subdir in dir.dirs() {
+        let subdir_path = path.join(dir.path());
+        assert!(subdir_path.exists());
+        validate_extracted(*subdir, &subdir_path);
+    }
+
+    // Check if the files at the root of this directory exist
+    for file in dir.files() {
+        let file_path = path.join(file.path());
+        assert!(file_path.exists());
     }
 }

--- a/include_dir/tests/integration_test.rs
+++ b/include_dir/tests/integration_test.rs
@@ -29,6 +29,7 @@ fn extract_all_files() {
     validate_directory(PARENT_DIR, root, root);
 }
 
+// TODO this needs to check that each file in the directory is present rather than checking that each extracted file is in the directory!
 fn validate_directory(dir: Dir<'_>, path: &Path, root: &Path) {
     for entry in path.read_dir().unwrap() {
         let entry = entry.unwrap().path();


### PR DESCRIPTION
This fixes #59 by adding support for recursive extraction based on the temporary fix I wrote [here](https://gist.github.com/arctic-hen7/397f32ca26528190e289ab895bebb970). Until this has been merged, that should be sufficient for anyone else having this problem.

All I've done is change the directory extraction code to directly recurse over every subdirectory, which solves this issue easily. I've also updated the integration tests to have two helper function, `validate_included` (the old `validate_directory`) and `validate_extracted` (new), which explicitly ensures that all files have been extracted.

Let me know of any changes you'd like me to make!