### PR TITLE
add timestamp metadata to dirs and files

### DIFF
--- a/include_dir/src/dir.rs
+++ b/include_dir/src/dir.rs
@@ -2,16 +2,28 @@ use crate::file::File;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// A directory entry.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Dir<'a> {
     #[doc(hidden)]
     pub path: &'a str,
+
     #[doc(hidden)]
     pub files: &'a [File<'a>],
+
     #[doc(hidden)]
     pub dirs: &'a [Dir<'a>],
+
+    #[doc(hidden)]
+    pub modified: Option<f64>,
+
+    #[doc(hidden)]
+    pub created: Option<f64>,
+
+    #[doc(hidden)]
+    pub accessed: Option<f64>,
 }
 
 impl<'a> Dir<'a> {
@@ -104,5 +116,26 @@ impl<'a> Dir<'a> {
         }
 
         extract_dir(*self, path)
+    }
+
+    /// The directory's created timestamp as of compilation time, if
+    /// available
+    pub fn created(&self) -> Option<SystemTime> {
+        self.created
+            .map(|secs| UNIX_EPOCH + Duration::from_secs_f64(secs))
+    }
+
+    /// The directory's last modified timestamp as of compilation
+    /// time, if available
+    pub fn modified(&self) -> Option<SystemTime> {
+        self.modified
+            .map(|secs| UNIX_EPOCH + Duration::from_secs_f64(secs))
+    }
+
+    /// The directory's last accessed timestamp as of compilation
+    /// time, if available
+    pub fn accessed(&self) -> Option<SystemTime> {
+        self.accessed
+            .map(|secs| UNIX_EPOCH + Duration::from_secs_f64(secs))
     }
 }

--- a/include_dir/src/file.rs
+++ b/include_dir/src/file.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Debug, Formatter};
 use std::path::Path;
 use std::str;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// A file with its contents stored in a `&'static [u8]`.
 #[derive(Copy, Clone, PartialEq)]
@@ -9,6 +10,15 @@ pub struct File<'a> {
     pub path: &'a str,
     #[doc(hidden)]
     pub contents: &'a [u8],
+
+    #[doc(hidden)]
+    pub modified: Option<f64>,
+
+    #[doc(hidden)]
+    pub accessed: Option<f64>,
+
+    #[doc(hidden)]
+    pub created: Option<f64>,
 }
 
 impl<'a> File<'a> {
@@ -27,6 +37,24 @@ impl<'a> File<'a> {
     pub fn contents_utf8(&self) -> Option<&'a str> {
         str::from_utf8(self.contents()).ok()
     }
+
+    /// The file's created timestamp as of compilation time, if available
+    pub fn created(&self) -> Option<SystemTime> {
+        self.created
+            .map(|secs| UNIX_EPOCH + Duration::from_secs_f64(secs))
+    }
+
+    /// The file's last modified timestamp as of compilation time, if available
+    pub fn modified(&self) -> Option<SystemTime> {
+        self.modified
+            .map(|secs| UNIX_EPOCH + Duration::from_secs_f64(secs))
+    }
+
+    /// The file's last accessed timestamp as of compilation time, if available
+    pub fn accessed(&self) -> Option<SystemTime> {
+        self.accessed
+            .map(|secs| UNIX_EPOCH + Duration::from_secs_f64(secs))
+    }
 }
 
 impl<'a> Debug for File<'a> {
@@ -34,6 +62,9 @@ impl<'a> Debug for File<'a> {
         f.debug_struct("File")
             .field("path", &self.path)
             .field("contents", &format!("<{} bytes>", self.contents.len()))
+            .field("created", &self.created())
+            .field("modified", &self.modified())
+            .field("accessed", &self.accessed())
             .finish()
     }
 }

--- a/include_dir_impl/src/file.rs
+++ b/include_dir_impl/src/file.rs
@@ -1,24 +1,36 @@
 use anyhow::Error;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-use std::path::{Path, PathBuf};
+use std::{
+    fs::Metadata,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub(crate) struct File {
     root_rel_path: PathBuf,
     abs_path: PathBuf,
+    metadata: Metadata,
+}
+
+impl PartialEq for File {
+    fn eq(&self, other: &Self) -> bool {
+        self.root_rel_path == other.root_rel_path && self.abs_path == other.abs_path
+    }
 }
 
 impl File {
     pub fn from_disk<Q: AsRef<Path>, P: Into<PathBuf>>(root: Q, path: P) -> Result<File, Error> {
         let abs_path = path.into();
         let root = root.as_ref();
-
         let root_rel_path = abs_path.strip_prefix(&root).unwrap().to_path_buf();
+        let metadata = std::fs::metadata(&abs_path)?;
 
         Ok(File {
             abs_path,
             root_rel_path,
+            metadata,
         })
     }
 }
@@ -27,14 +39,27 @@ impl ToTokens for File {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let root_rel_path = self.root_rel_path.display().to_string();
         let abs_path = self.abs_path.display().to_string();
-
+        let modified = timestamp_to_tokenstream(self.metadata.modified());
+        let created = timestamp_to_tokenstream(self.metadata.created());
+        let accessed = timestamp_to_tokenstream(self.metadata.accessed());
         let tok = quote! {
             $crate::File {
                 path: #root_rel_path,
                 contents: include_bytes!(#abs_path),
+                modified: #modified,
+                created: #created,
+                accessed: #accessed
             }
         };
 
         tok.to_tokens(tokens);
     }
+}
+
+fn timestamp_to_tokenstream(time: std::io::Result<SystemTime>) -> TokenStream {
+    time.ok()
+        .and_then(|m| m.duration_since(UNIX_EPOCH).ok())
+        .map(|dur| dur.as_secs_f64())
+        .map(|secs| quote! { Some(#secs) }.to_token_stream())
+        .unwrap_or_else(|| quote! { None }.to_token_stream())
 }

--- a/include_dir_impl/src/file.rs
+++ b/include_dir_impl/src/file.rs
@@ -1,10 +1,10 @@
+use crate::timestamp_to_tokenstream;
 use anyhow::Error;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use std::{
     fs::Metadata,
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 #[derive(Debug, Clone)]
@@ -54,12 +54,4 @@ impl ToTokens for File {
 
         tok.to_tokens(tokens);
     }
-}
-
-fn timestamp_to_tokenstream(time: std::io::Result<SystemTime>) -> TokenStream {
-    time.ok()
-        .and_then(|m| m.duration_since(UNIX_EPOCH).ok())
-        .map(|dur| dur.as_secs_f64())
-        .map(|secs| quote! { Some(#secs) }.to_token_stream())
-        .unwrap_or_else(|| quote! { None }.to_token_stream())
 }


### PR DESCRIPTION
Hi! Thanks for include_dir! I noticed #16 and thought I'd add a first bit of cross-platform metadata to included dirs and files: The created/accessed/modified timestamps.
