### PR TITLE
Add try_include_dir for fallible directory inclusion

### DIFF
--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -43,7 +43,7 @@
     missing_copy_implementations,
     missing_debug_implementations,
     missing_docs,
-    rust_2018_idioms,
+    rust_2018_idioms
 )]
 
 #[allow(unused_imports)]
@@ -66,6 +66,10 @@ pub use crate::globs::DirEntry;
 #[doc(hidden)]
 #[proc_macro_hack]
 pub use include_dir_impl::include_dir;
+
+#[doc(hidden)]
+#[proc_macro_hack]
+pub use include_dir_impl::try_include_dir;
 
 /// Example the output generated when running `include_dir!()` on itself.
 #[cfg(feature = "example-output")]

--- a/include_dir_impl/src/dir.rs
+++ b/include_dir_impl/src/dir.rs
@@ -17,7 +17,7 @@ impl Dir {
         let abs_path = path.into();
         let root = root.as_ref();
 
-        let root_rel_path = abs_path.strip_prefix(&root).unwrap().to_path_buf();
+        let root_rel_path = abs_path.strip_prefix(&root)?.to_path_buf();
 
         if !abs_path.exists() {
             return Err(format_err!("The directory doesn't exist"));

--- a/include_dir_impl/src/lib.rs
+++ b/include_dir_impl/src/lib.rs
@@ -6,12 +6,12 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use proc_macro_hack::proc_macro_hack;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{parse_macro_input, LitStr};
 
 use crate::dir::Dir;
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 mod dir;
 mod file;
@@ -29,9 +29,36 @@ pub fn include_dir(input: TokenStream) -> TokenStream {
 
     let path = path.canonicalize().expect("Can't normalize the path");
 
-    let dir = Dir::from_disk(&path, &path).expect("Couldn't load the directory");
+    Dir::from_disk(&path, &path)
+        .expect("Couldn't load the directory")
+        .to_token_stream()
+        .into()
+}
 
-    TokenStream::from(quote! {
-        #dir
-    })
+#[proc_macro_hack]
+pub fn try_include_dir(input: TokenStream) -> TokenStream {
+    let input: LitStr = parse_macro_input!(input as LitStr);
+    let crate_root = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    let path = PathBuf::from(crate_root).join(input.value());
+    match load_dir(path) {
+        Ok(dir) => quote! { Result::<$crate::Dir, &'static str>::Ok(#dir) },
+        Err(err) => quote! { Result::<$crate::Dir, &'static str>::Err(#err) },
+    }
+    .into()
+}
+
+fn load_dir(path: impl AsRef<Path>) -> Result<Dir, String> {
+    let path = path.as_ref();
+
+    if !path.exists() {
+        return Err(format!("\"{}\" doesn't exist", path.display()));
+    }
+
+    let path = path
+        .canonicalize()
+        .map_err(|_| String::from("Can't normalize the path"))?;
+
+    Dir::from_disk(&path, &path)
+        .map_err(|e| format!("Couldn't load the directory: {}", e.to_string()))
 }


### PR DESCRIPTION
Currently, `include_dir::include_dir` panics if the directory does not exist, which makes it difficult to use in library code that can't guarantee the existence of a particular root directory. `include_dir::try_include_dir` introduces a way to attempt to include a directory but compile in a Result::Err literal instead of the directory, allowing library code to use this in a macro and gracefully handle the scenario where the directory is missing.