### PR TITLE
dir/extract: add mode for overwriting existing files

### DIFF
--- a/include_dir/src/lib.rs
+++ b/include_dir/src/lib.rs
@@ -52,7 +52,9 @@ extern crate include_dir_impl;
 #[macro_use]
 extern crate proc_macro_hack;
 
-mod dir;
+/// Directory entry functionality.
+pub mod dir;
+
 mod file;
 
 #[cfg(feature = "search")]

--- a/include_dir/tests/integration_test.rs
+++ b/include_dir/tests/integration_test.rs
@@ -1,4 +1,4 @@
-use include_dir::{include_dir, Dir};
+use include_dir::{dir::ExtractMode, include_dir, Dir};
 use std::path::Path;
 use tempdir::TempDir;
 
@@ -12,9 +12,8 @@ fn included_all_files() {
     validate_included(PARENT_DIR, root, root);
 }
 
-#[test]
-fn extract_all_files() {
-    let tmpdir = TempDir::new(
+fn tempdir() -> Result<TempDir, std::io::Error> {
+    TempDir::new(
         format!(
             "{}-{}-test",
             env!("CARGO_PKG_NAME"),
@@ -22,10 +21,27 @@ fn extract_all_files() {
         )
         .as_str(),
     )
-    .unwrap();
-    let root = tmpdir.path();
-    PARENT_DIR.extract(root).unwrap();
+}
 
+#[test]
+fn extract_all_files_fail() {
+    let tmpdir = tempdir().unwrap();
+    let root = tmpdir.path();
+    PARENT_DIR.extract(root, ExtractMode::FailIfExists).unwrap();
+    validate_extracted(PARENT_DIR, root);
+
+    assert!(PARENT_DIR.extract(root, ExtractMode::FailIfExists).is_err());
+}
+
+#[test]
+fn extract_all_files_overwrite() {
+    let tmpdir = tempdir().unwrap();
+    let root = tmpdir.path();
+
+    PARENT_DIR.extract(root, ExtractMode::Overwrite).unwrap();
+    validate_extracted(PARENT_DIR, root);
+
+    PARENT_DIR.extract(root, ExtractMode::Overwrite).unwrap();
     validate_extracted(PARENT_DIR, root);
 }
 


### PR DESCRIPTION
A `dir::ExtractMode` enum is added with the options `Overwrite` and `FailIfExists`. The latter is the current behavior. The former truncates any already existing files.