### PR TITLE
specify 'a lifetime on file contents

### DIFF
--- a/include_dir/src/file.rs
+++ b/include_dir/src/file.rs
@@ -30,12 +30,12 @@ impl<'a> File<'a> {
     }
 
     /// The file's raw contents.
-    pub fn contents(&self) -> &[u8] {
+    pub fn contents(&self) -> &'a [u8] {
         self.contents
     }
 
     /// The file's contents interpreted as a string.
-    pub fn contents_utf8(&self) -> Option<&str> {
+    pub fn contents_utf8(&self) -> Option<&'a str> {
         std::str::from_utf8(self.contents()).ok()
     }
 }


### PR DESCRIPTION
Without this, the lifetime of `&self` is inferred, which might not live as long as `'a` (often/always `'static`)

I believe this is semver-patch because `'a` always outlives the self borrow lifetime