### PR TITLE
Add test to check issue #99

### DIFF
--- a/include_dir/tests/integration_test.rs
+++ b/include_dir/tests/integration_test.rs
@@ -94,3 +94,13 @@ fn msrv_is_in_sync() {
         .unwrap();
     assert_eq!(workflow_msrv, msrv);
 }
+
+#[test]
+fn include_dir_conditionally() {
+    static CONDITIONAL_PARENT_DIR: Option<Dir<'_>> = if true {
+        Some(include_dir!("$CARGO_MANIFEST_DIR"))
+    } else {
+        None
+    };
+    let _ = CONDITIONAL_PARENT_DIR.as_ref().unwrap();
+}


### PR DESCRIPTION
I've added a new test which is essentially a slight simplification of the original error case in #99 . I've checked manually - if I revert the change from https://github.com/Michael-F-Bryan/include_dir/commit/20f94752dae75025f5bea4dd2dbb76e0fbe3ac6b, the test fails to compile. Not sure if this is a good way to check this, but at least for this specific regression it works.