### PR TITLE
Ensure license file is published with each crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 edition = "2021"
 rust-version = "1.64"
 license = "MIT"
+license-file = "LICENSE"
 readme = "README.md"
 version = "0.7.4"
 authors = ["Michael Bryan <michaelfbryan@gmail.com>"]

--- a/include_dir/Cargo.toml
+++ b/include_dir/Cargo.toml
@@ -6,6 +6,7 @@ categories = ["development-tools", "web-programming", "game-engines"]
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+license-file.workspace = true
 readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -4,6 +4,7 @@ description = "The procedural macro used by include_dir"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+license-file.workspace = true
 readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
As the license file is present at the root of the repository, it isn't part of any crate on crates.io, as those lie in subfolders. Ensure this file is published by telling cargo where to find it.